### PR TITLE
🐬 PDX-77: Push Docker image in GH-Actions

### DIFF
--- a/.github/workflows/push_docker_image.yaml
+++ b/.github/workflows/push_docker_image.yaml
@@ -1,0 +1,36 @@
+name: push docker image
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build_and_push:
+    name: build_and_push (${{ matrix.docker.repo }})
+    strategy:
+      matrix:
+        docker:
+          - repo: planetariumhq/9c-bridge
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: login
+        run: |
+          docker login \
+            --username '${{ secrets.DOCKER_USERNAME }}' \
+            --password '${{ secrets.DOCKER_ACCESS_TOKEN }}'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: build-and-push
+        run: |
+          docker buildx build . \
+            --platform linux/arm64/v8,linux/amd64 \
+            --tag ${{ matrix.docker.repo }}:git-${{ github.sha }} \
+            --push


### PR DESCRIPTION
[This Docker image](https://hub.docker.com/layers/planetariumhq/9c-bridge/git-098e8ae9877afd8d462723af14f8f7fd76a3789b/images/sha256-f84e178fc3489e5fbf4e14a5a2fd65ad9350cf3469640f1c8343ff6c00359d20?context=explore) is deployed by [the workflow](https://github.com/planetarium/NineChronicles.Bridge/actions/runs/6826621073). It resolves a part of #2.