### PR TITLE
🔨 PDX-116: Handle `transfer_asset[0-9]*` only

### DIFF
--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -128,7 +128,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
             const query = `query GetAssetTransferred($blockIndex: Long!)
             {             
                 transaction {
-                    ncTransactions(startingBlockIndex: $blockIndex, actionType: "transfer_asset*", limit: 1) {
+                    ncTransactions(startingBlockIndex: $blockIndex, actionType: "^transfer_asset[0-9]*$", limit: 1) {
                         id
                         actions {
                             raw


### PR DESCRIPTION
You can test the GraphQL query.

```graphql
query GetAssetTransferred($blockIndex: Long!)
{             
    transaction {
        ncTransactions(startingBlockIndex: $blockIndex, actionType: "^transfer_asset[0-9]*$", limit: 1) {
            id
            actions {
                raw
            }
        }
    }
}
```

query variable
```json
{
  "blockIndex": 156805
}
```

https://heimdall-internal-rpc-1.nine-chronicles.com/ui/playground