### PR TITLE
Forward garage memo to mint asset action

### DIFF
--- a/src/interfaces/minter.ts
+++ b/src/interfaces/minter.ts
@@ -19,5 +19,5 @@ export interface IFungibleItems
 export interface IMinter {
     getMinterAddress(): Promise<Address>;
 
-    mintAssets(assets: [IFungibleAssetValues | IFungibleItems]): Promise<TxId>;
+    mintAssets(assets: [IFungibleAssetValues | IFungibleItems], memo: string | null): Promise<TxId>;
 }

--- a/src/minter.spec.ts
+++ b/src/minter.spec.ts
@@ -28,7 +28,7 @@ test("mint fav", async () => {
             currency: ncg,
             rawValue: BigInt(amount.toNumber()),
         },
-    }]);
+    }], null);
 });
 
 test("mint fis", async () => {
@@ -44,5 +44,5 @@ test("mint fis", async () => {
         recipient: "0x37fd092455B529cFAE3Bf3b58201cE029231cDBe", 
         fungibleItemId: "1a755098a2bc0659a063107df62e2ff9b3cdaba34d96b79519f504b996f53820", 
         count: 100
-    }]);
+    }], null);
 });

--- a/src/minter.ts
+++ b/src/minter.ts
@@ -12,11 +12,11 @@ export class Minter implements IMinter {
         this.signer = signer;
     }
     
-    async mintAssets(assets: [IFungibleAssetValues | IFungibleItems]): Promise<string> {
+    async mintAssets(assets: [IFungibleAssetValues | IFungibleItems], memo: string | null): Promise<string> {
         const action = new RecordView(            
             {
                 type_id: "mint_assets",
-                values: assets.map(encodeMintSpec),
+                values: [memo, ...assets.map(encodeMintSpec)],
             },
             "text"
         );

--- a/src/observers/asset-transferred-observer.ts
+++ b/src/observers/asset-transferred-observer.ts
@@ -40,7 +40,7 @@ export class AssetTransferredObserver implements IObserver<{
                 rawValue: amount.rawValue,
             };
 
-            await this._minter.mintAssets([{ recipient, amount: amountToMint }]);
+            await this._minter.mintAssets([{ recipient, amount: amountToMint }], null);
         }
     }
 }

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -27,7 +27,7 @@ export class GarageObserver implements IObserver<{
                 txId,
             });
 
-            const { agentAddress, avatarAddress } = parseMemo(memo);
+            const { agentAddress, avatarAddress, memo: memoForMinter } = parseMemo(memo);
 
             const requests: (IFungibleAssetValues | IFungibleItems)[] = [];
             for (const fa of fungibleAssetValues) {
@@ -47,18 +47,18 @@ export class GarageObserver implements IObserver<{
 
             if (requests.length !== 0) {
                 // @ts-ignore
-                await this._minter.mintAssets(requests);
+                await this._minter.mintAssets(requests, memoForMinter);
             }
         }
-
     }
 }
-function parseMemo(memo: string): { agentAddress: string; avatarAddress: string; } {
+function parseMemo(memo: string): { agentAddress: string; avatarAddress: string; memo: string; } {
     const parsed = JSON.parse(memo);
 
     return {
         agentAddress: parsed[0],
         avatarAddress: parsed[1],
+        memo: parsed[2],
     };
 }
 


### PR DESCRIPTION
Note: this PR should be merged after https://github.com/planetarium/lib9c/pull/2237

This PR adds a bunch of codes to forward `UnloadFromMyGarages.Memo`'s 3rd field as memo of `MintAssets` action will be created.