### PR TITLE
🔨 PDX-122: Check `transactionResult.txStatus` is `SUCCESS`

### DIFF
--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -12,6 +12,8 @@ import { IHeadlessGraphQLClient } from "./interfaces/headless-graphql-client";
 import { AssetTransferredEvent } from "./types/asset-transferred-event";
 import { BlockHash } from "./types/block-hash";
 import { GarageUnloadEvent } from "./types/garage-unload-event";
+import { TransactionResult } from "./types/transaction-result";
+import { TxId } from "./types/txid";
 
 function delay(ms: number): Promise<void> {
     return new Promise((resolve) => {
@@ -238,6 +240,18 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
         });
 
         return response.data.data.stageTransaction;
+    }
+
+    async getTransactionResult(txId: TxId): Promise<TransactionResult> {
+        const query =
+            "query GetTransactionResult($txId: TxId!) { transaction { transactionResult(txId: $txId) { txStatus } } }";
+        const response = await this.graphqlRequest({
+            operationName: "GetTransactionResult",
+            query,
+            variables: { txId },
+        });
+
+        return response.data.data.transaction.transactionResult;
     }
 
     private async graphqlRequest(

--- a/src/interfaces/headless-graphql-client.ts
+++ b/src/interfaces/headless-graphql-client.ts
@@ -2,6 +2,8 @@ import { Address } from "@planetarium/account";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { BlockHash } from "../types/block-hash";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
+import { TransactionResult } from "../types/transaction-result";
+import { TxId } from "../types/txid";
 
 export interface IHeadlessGraphQLClient {
     readonly endpoint: string;
@@ -21,4 +23,5 @@ export interface IHeadlessGraphQLClient {
     getNextTxNonce(address: string): Promise<number>;
     getGenesisHash(): Promise<string>;
     stageTransaction(payload: string): Promise<string>;
+    getTransactionResult(txId: TxId): Promise<TransactionResult>;
 }

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -36,7 +36,18 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
             this._avatarAddress,
         );
 
-        return events.map((ev) => {
+        const successEvents: GarageUnloadEvent[] = [];
+        for (const event of events) {
+            const { txStatus } =
+                await this._headlessGraphQLClient.getTransactionResult(
+                    event.txId,
+                );
+            if (txStatus === "SUCCESS") {
+                successEvents.push(event);
+            }
+        }
+
+        return successEvents.map((ev) => {
             return { blockHash, ...ev };
         });
     }

--- a/src/types/transaction-result.ts
+++ b/src/types/transaction-result.ts
@@ -1,0 +1,5 @@
+export type TransactionStatus = "INVALID" | "STAGING" | "FAILURE" | "SUCCESS";
+
+export interface TransactionResult {
+    txStatus: TransactionStatus;
+}


### PR DESCRIPTION
**⚠️ IT MUST BE MERGED. ⚠️** 

It resolves #23.

When I added logs:

```typescript
if (txStatus === "SUCCESS") {
    successEvents.push(event);
} else {
    console.log(
        "skip beceause txStatus is",
        txStatus,
        "txid is",
        event.txId,
    );
}
```

It shows:

```
skip beceause txStatus is FAILURE txid is f8da1f28d252b295c0b59e0b3565a4560bd50f3185d2f785fc9fa088f4e0e2c3
```

I tried to send a `TransferAsset` action to fail.

In the current Heimdall version, it mints the assets. ⚠️ 

https://heimdall.9cscan.com/tx/1fd6c3023eb63c07ab00ff56f9837be601258759924c082e7654bf94fc39d80f

![image](https://github.com/planetarium/NineChronicles.Bridge/assets/26626194/357a15bc-c914-4777-ab70-c5fbdda58ed6)
