### PR TITLE
Workaround `ncTransactions` bug

### DIFF
--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -29,7 +29,7 @@ export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransfe
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events =
             await this._headlessGraphQLClient.getAssetTransferredEvents(
-                blockIndex,
+                blockIndex - 1,  // need to wait 1 block far from tip due to 9c headless' bug.
                 this._address,
             );
 

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -31,7 +31,7 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
         const blockHash =
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events = await this._headlessGraphQLClient.getGarageUnloadEvents(
-            blockIndex,
+            blockIndex - 1, // need to wait 1 block far from tip due to 9c headless' bug.
             this._agentAddress,
             this._avatarAddress,
         );


### PR DESCRIPTION
This PR introduce workaround that waiting 1 block from tip for fit `ncTransactions` query bug. (see also https://github.com/planetarium/NineChronicles.Headless/issues/2305)