### PR TITLE
🔨 PDX-80: Load and store latest block by monitors

### DIFF
--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -26,7 +26,7 @@ test(".getGarageUnloadEvents()", async () => {
     const account = RawPrivateKey.fromHex("");
     const signer = new Signer(account, heimdallClient);
     const minter = new Minter(signer);
-    const observer = new GarageObserver(monitorStateStore, minter);
+    const observer = new GarageObserver(minter);
     await observer.notify({
         blockHash: "",
         events: x.map((ev) => {
@@ -47,7 +47,7 @@ test("getAssetTransferredEvents()", async () => {
     const signer = new Signer(account, heimdallClient);
     const minter = new Minter(signer);
     const stateStore = await Sqlite3MonitorStateStore.open("test");
-    const observer = new AssetTransferredObserver(stateStore, minter);
+    const observer = new AssetTransferredObserver(minter);
     await observer.notify({
         blockHash: "",
         events: evs.map((ev) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { AssetTransfer } from "./asset-transfer";
 import { HeadlessGraphQLClient } from "./headless-graphql-client";
 import { IMonitorStateStore } from "./interfaces/monitor-state-store";
 import { Minter } from "./minter";
+import { getMonitorStateHandler } from "./monitor-state-handler";
 import { AssetsTransferredMonitor } from "./monitors/assets-transferred-monitor";
 import { GarageUnloadMonitor } from "./monitors/garage-unload-monitor";
 import { AssetDownstreamObserver } from "./observers/asset-downstream-observer";
@@ -34,20 +35,29 @@ import { Sqlite3MonitorStateStore } from "./sqlite3-monitor-state-store";
 
     const upstreamAssetsTransferredMonitorMonitor =
         new AssetsTransferredMonitor(
-            monitorStateStore,
+            getMonitorStateHandler(
+                monitorStateStore,
+                "upstreamAssetTransferMonitor",
+            ),
             shutdownHandler,
             upstreamGQLClient,
             Address.fromHex(process.env.NC_VAULT_ADDRESS),
         );
     const downstreamAssetsTransferredMonitorMonitor =
         new AssetsTransferredMonitor(
-            monitorStateStore,
+            getMonitorStateHandler(
+                monitorStateStore,
+                "downstreamAssetTransferMonitor",
+            ),
             shutdownHandler,
             downstreamGQLClient,
             Address.fromHex(process.env.NC_VAULT_ADDRESS),
         );
     const garageMonitor = new GarageUnloadMonitor(
-        monitorStateStore,
+        getMonitorStateHandler(
+            monitorStateStore,
+            "upstreamGarageUnloadMonitor",
+        ),
         shutdownHandler,
         upstreamGQLClient,
         Address.fromHex(process.env.NC_VAULT_ADDRESS),

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,20 +34,20 @@ import { Sqlite3MonitorStateStore } from "./sqlite3-monitor-state-store";
 
     const upstreamAssetsTransferredMonitorMonitor =
         new AssetsTransferredMonitor(
-            await monitorStateStore.load("nineChronicles"),
+            monitorStateStore,
             shutdownHandler,
             upstreamGQLClient,
             Address.fromHex(process.env.NC_VAULT_ADDRESS),
         );
     const downstreamAssetsTransferredMonitorMonitor =
         new AssetsTransferredMonitor(
-            await monitorStateStore.load("nineChronicles"),
+            monitorStateStore,
             shutdownHandler,
             downstreamGQLClient,
             Address.fromHex(process.env.NC_VAULT_ADDRESS),
         );
     const garageMonitor = new GarageUnloadMonitor(
-        await monitorStateStore.load("nineChronicles"),
+        monitorStateStore,
         shutdownHandler,
         upstreamGQLClient,
         Address.fromHex(process.env.NC_VAULT_ADDRESS),
@@ -70,14 +70,14 @@ import { Sqlite3MonitorStateStore } from "./sqlite3-monitor-state-store";
     const downstreamBurner = new AssetBurner(downstreamSigner);
 
     upstreamAssetsTransferredMonitorMonitor.attach(
-        new AssetTransferredObserver(monitorStateStore, minter),
+        new AssetTransferredObserver(minter),
     );
 
     downstreamAssetsTransferredMonitorMonitor.attach(
         new AssetDownstreamObserver(upstreamTransfer, downstreamBurner),
     );
 
-    garageMonitor.attach(new GarageObserver(monitorStateStore, minter));
+    garageMonitor.attach(new GarageObserver(minter));
 
     upstreamAssetsTransferredMonitorMonitor.run();
     downstreamAssetsTransferredMonitorMonitor.run();

--- a/src/interfaces/monitor-state-handler.ts
+++ b/src/interfaces/monitor-state-handler.ts
@@ -1,0 +1,6 @@
+import { BlockHash } from "../types/block-hash";
+
+export interface IMonitorStateHandler {
+    load(): Promise<BlockHash | null>;
+    store(blockHash: BlockHash): Promise<void>;
+}

--- a/src/interfaces/monitor-state-store.ts
+++ b/src/interfaces/monitor-state-store.ts
@@ -1,9 +1,6 @@
-import { TransactionLocation } from "../types/transaction-location";
+import { BlockHash } from "../types/block-hash";
 
 export interface IMonitorStateStore {
-    store(
-        network: string,
-        transactionLocation: TransactionLocation,
-    ): Promise<void>;
-    load(network: string): Promise<TransactionLocation | null>;
+    store(network: string, blockHash: BlockHash): Promise<void>;
+    load(network: string): Promise<BlockHash | null>;
 }

--- a/src/monitor-state-handler.ts
+++ b/src/monitor-state-handler.ts
@@ -1,0 +1,16 @@
+import { IMonitorStateHandler } from "./interfaces/monitor-state-handler";
+import { IMonitorStateStore } from "./interfaces/monitor-state-store";
+
+export function getMonitorStateHandler(
+    stateStore: IMonitorStateStore,
+    key: string,
+): IMonitorStateHandler {
+    return {
+        load() {
+            return stateStore.load(key);
+        },
+        store(blockHash) {
+            return stateStore.store(key, blockHash);
+        },
+    };
+}

--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -1,6 +1,6 @@
 import { Address } from "@planetarium/account";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
-import { IMonitorStateStore } from "../interfaces/monitor-state-store";
+import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
@@ -10,12 +10,12 @@ export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransfe
     private readonly _address: Address;
 
     constructor(
-        monitorStateStore: IMonitorStateStore,
+        monitorStateHandler: IMonitorStateHandler,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         address: Address,
     ) {
-        super(monitorStateStore, shutdownChecker, headlessGraphQLClient);
+        super(monitorStateHandler, shutdownChecker, headlessGraphQLClient);
         this._address = address;
     }
 

--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -1,5 +1,6 @@
 import { Address } from "@planetarium/account";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IMonitorStateStore } from "../interfaces/monitor-state-store";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
@@ -9,16 +10,12 @@ export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransfe
     private readonly _address: Address;
 
     constructor(
-        latestTransactionLocation: TransactionLocation | null,
+        monitorStateStore: IMonitorStateStore,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         address: Address,
     ) {
-        super(
-            latestTransactionLocation,
-            shutdownChecker,
-            headlessGraphQLClient,
-        );
+        super(monitorStateStore, shutdownChecker, headlessGraphQLClient);
         this._address = address;
     }
 

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -1,6 +1,6 @@
 import { Address } from "@planetarium/account";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
-import { IMonitorStateStore } from "../interfaces/monitor-state-store";
+import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
@@ -11,13 +11,13 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
     private readonly _avatarAddress: Address;
 
     constructor(
-        monitorStateStore: IMonitorStateStore,
+        monitorStateHandler: IMonitorStateHandler,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         agentAddress: Address,
         avatarAddress: Address,
     ) {
-        super(monitorStateStore, shutdownChecker, headlessGraphQLClient);
+        super(monitorStateHandler, shutdownChecker, headlessGraphQLClient);
         this._agentAddress = agentAddress;
         this._avatarAddress = avatarAddress;
     }

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -1,5 +1,6 @@
 import { Address } from "@planetarium/account";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IMonitorStateStore } from "../interfaces/monitor-state-store";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
@@ -10,17 +11,13 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
     private readonly _avatarAddress: Address;
 
     constructor(
-        latestTransactionLocation: TransactionLocation | null,
+        monitorStateStore: IMonitorStateStore,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         agentAddress: Address,
         avatarAddress: Address,
     ) {
-        super(
-            latestTransactionLocation,
-            shutdownChecker,
-            headlessGraphQLClient,
-        );
+        super(monitorStateStore, shutdownChecker, headlessGraphQLClient);
         this._agentAddress = agentAddress;
         this._avatarAddress = avatarAddress;
     }

--- a/src/monitors/ninechronicles-block-monitor.ts
+++ b/src/monitors/ninechronicles-block-monitor.ts
@@ -1,5 +1,5 @@
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
-import { IMonitorStateStore } from "../interfaces/monitor-state-store";
+import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
 import { TriggerableMonitor } from "./triggerable-monitor";
@@ -12,11 +12,11 @@ export abstract class NineChroniclesMonitor<
     protected readonly _headlessGraphQLClient: IHeadlessGraphQLClient;
 
     constructor(
-        monitorStateStore: IMonitorStateStore,
+        monitorStateHandler: IMonitorStateHandler,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
     ) {
-        super(monitorStateStore, shutdownChecker);
+        super(monitorStateHandler, shutdownChecker);
 
         this._headlessGraphQLClient = headlessGraphQLClient;
     }

--- a/src/monitors/ninechronicles-block-monitor.ts
+++ b/src/monitors/ninechronicles-block-monitor.ts
@@ -1,4 +1,5 @@
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IMonitorStateStore } from "../interfaces/monitor-state-store";
 import { ShutdownChecker } from "../types/shutdown-checker";
 import { TransactionLocation } from "../types/transaction-location";
 import { TriggerableMonitor } from "./triggerable-monitor";
@@ -11,11 +12,11 @@ export abstract class NineChroniclesMonitor<
     protected readonly _headlessGraphQLClient: IHeadlessGraphQLClient;
 
     constructor(
-        latestTransactionLocation: TransactionLocation | null,
+        monitorStateStore: IMonitorStateStore,
         shutdownChecker: ShutdownChecker,
         headlessGraphQLClient: IHeadlessGraphQLClient,
     ) {
-        super(latestTransactionLocation, shutdownChecker);
+        super(monitorStateStore, shutdownChecker);
 
         this._headlessGraphQLClient = headlessGraphQLClient;
     }

--- a/src/observers/asset-transferred-observer.ts
+++ b/src/observers/asset-transferred-observer.ts
@@ -1,7 +1,6 @@
 import { FungibleAssetValue } from "@planetarium/tx";
 import { IObserver } from ".";
 import { IMinter } from "../interfaces/minter";
-import { IMonitorStateStore } from "../interfaces/monitor-state-store";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { BlockHash } from "../types/block-hash";
 import { TransactionLocation } from "../types/transaction-location";
@@ -13,11 +12,9 @@ export class AssetTransferredObserver
             events: (AssetTransferredEvent & TransactionLocation)[];
         }>
 {
-    private readonly _monitorStateStore: IMonitorStateStore;
     private readonly _minter: IMinter;
 
-    constructor(monitorStateStore: IMonitorStateStore, minter: IMinter) {
-        this._monitorStateStore = monitorStateStore;
+    constructor(minter: IMinter) {
         this._minter = minter;
     }
 
@@ -28,11 +25,6 @@ export class AssetTransferredObserver
         const { events } = data;
 
         for (const { blockHash, txId, amount, memo: recipient } of events) {
-            await this._monitorStateStore.store("nine-chronicles", {
-                blockHash,
-                txId,
-            });
-
             // TODO check memo & refund if needed.
 
             // Strip minters to mint well.

--- a/src/observers/garage-observer.spec.ts
+++ b/src/observers/garage-observer.spec.ts
@@ -17,7 +17,7 @@ test("notify", async () => {
         ),
     );
     const minter = new Minter(signer);
-    const observer = new GarageObserver(monitorStateStore, minter);
+    const observer = new GarageObserver(minter);
     observer.notify({
         blockHash: "xxx",
         events: [

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -4,7 +4,6 @@ import {
     IFungibleItems,
     IMinter,
 } from "../interfaces/minter";
-import { IMonitorStateStore } from "../interfaces/monitor-state-store";
 import { BlockHash } from "../types/block-hash";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { TransactionLocation } from "../types/transaction-location";
@@ -17,11 +16,9 @@ export class GarageObserver
         }>
 {
     private readonly _minter: IMinter;
-    private readonly _monitorStateStore: IMonitorStateStore;
 
-    constructor(monitorStateStore: IMonitorStateStore, minter: IMinter) {
+    constructor(minter: IMinter) {
         this._minter = minter;
-        this._monitorStateStore = monitorStateStore;
     }
 
     async notify(data: {
@@ -37,11 +34,6 @@ export class GarageObserver
             fungibleItems,
             memo,
         } of events) {
-            await this._monitorStateStore.store("nine-chronicles", {
-                blockHash,
-                txId,
-            });
-
             const {
                 agentAddress,
                 avatarAddress,


### PR DESCRIPTION
# Overview

- Since #27, the bridge started to support graceful shutdown.
- The pattern that observers store `TransactionLocation` and loaded by monitors, was invalid because it couldn't have multiple observers by monitors.

# ⚠️ Breaking change

- Please delete the SQLite3 file.
