### PR TITLE
Record Staged Transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/jest": "^29.5.7",
     "@types/node": "^20.5.9",
     "jest": "^29.7.0",
+    "prisma": "^5.6.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },
@@ -27,6 +28,7 @@
     "@planetarium/account-aws-kms": "^3.7.0",
     "@planetarium/bencodex": "^0.2.2",
     "@planetarium/tx": "^3.7.0",
+    "@prisma/client": "5.6.0",
     "@sentry/node": "^7.76.0",
     "@slack/web-api": "^6.10.0",
     "@urql/core": "^4.2.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,66 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum ActionType {
+  BURN
+  MINT
+  TRANSFER
+}
+
+enum TxResult {
+  INVALID
+  STAGING
+  SUCCESS
+  FAILURE
+}
+
+model Job {
+  id String @id
+  sender String
+  recipient String
+  src_planet String
+  ticker String
+  amount String
+  createdAt DateTime @default(now())
+  startedAt DateTime?
+  processedAt DateTime?
+  updatedAt DateTime @updatedAt
+
+  executions JobExecution[]
+}
+
+model Transaction {
+  txId String @id @unique
+  nonce BigInt @unique
+  raw Bytes
+  lastStatus TxResult?
+  statusUpdatedAt DateTime @default(now())
+
+  executions JobExecution[]
+}
+
+model JobExecution {
+  jobId String
+  job Job @relation(fields: [jobId], references: [id])
+
+  transactionId String
+  transaction Transaction @relation(fields: [transactionId], references: [txId])
+
+  actionType ActionType 
+  retries Int @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@id([jobId, transactionId])
+  @@unique([jobId, retries])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,19 +23,30 @@ enum TxResult {
   FAILURE
 }
 
-model Job {
-  id String @id
+model Request {
+  req_tx_id String @id @unique
   sender String
+  senderAvatar String?
   recipient String
+  recipientAvatar String?
   src_planet String
   ticker String
   amount String
+  timestamp DateTime
+
+  job Job?
+}
+
+model Job {
+  req_tx_id String @id @unique
+  request Request @relation(fields: [req_tx_id], references: [req_tx_id])
+
   createdAt DateTime @default(now())
   startedAt DateTime?
   processedAt DateTime?
   updatedAt DateTime @updatedAt
 
-  executions JobExecution[]
+  execution JobExecution[]
 }
 
 model Transaction {
@@ -50,8 +61,9 @@ model Transaction {
 
 model JobExecution {
   jobId String
-  job Job @relation(fields: [jobId], references: [id])
+  job Job @relation(fields: [jobId], references: [req_tx_id])
 
+  dstPlanetId String
   transactionId String
   transaction Transaction @relation(fields: [transactionId], references: [txId])
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum RequestType {
+  UNLOAD_GARAGE
+  TRANSFER_ASSETS
+}
+
 enum ActionType {
   BURN
   MINT
@@ -22,19 +27,33 @@ enum TxResult {
   SUCCESS
   FAILURE
 }
-
 model Request {
   req_tx_id String @id @unique
-  sender String
-  senderAvatar String?
-  recipient String
-  recipientAvatar String?
+  req_type RequestType
   src_planet String
-  ticker String
-  amount String
   timestamp DateTime
 
   job Job?
+  transfer TrasferAssetsRequest?
+  garage UnloadGarageRequest?
+}
+model TrasferAssetsRequest {
+  req_tx_id   String   @id @unique
+  request     Request  @relation(fields: [req_tx_id], references: [req_tx_id])
+  sender String
+  recipient String
+  ticker String
+  amount String
+}
+
+model UnloadGarageRequest {
+  req_tx_id   String   @id @unique
+  request     Request  @relation(fields: [req_tx_id], references: [req_tx_id])
+  sender String
+  recipient String
+  recipientAvatar String
+  FungibleAssetValues Json?
+  FungibleItems Json?
 }
 
 model Job {

--- a/src/asset-burner.ts
+++ b/src/asset-burner.ts
@@ -10,6 +10,10 @@ export class AssetBurner implements IAssetBurner {
         this.signer = signer;
     }
 
+    getBurnerPlanet(): string {
+        return this.signer.getSignPlanet();
+    }
+
     async burn(amount: FungibleAssetValue, memo: string): Promise<string> {
         const sender = (await this.signer.getAddress()).toBytes();
         const action = new RecordView(

--- a/src/asset-transfer.ts
+++ b/src/asset-transfer.ts
@@ -15,6 +15,9 @@ export class AssetTransfer implements IAssetTransfer {
     constructor(signer: Signer) {
         this.signer = signer;
     }
+    getTransferPlanet(): string {
+        return this.signer.getSignPlanet();
+    }
 
     async transfer(
         recipient: Address,

--- a/src/graphql/GetAssetTransferred.graphql
+++ b/src/graphql/GetAssetTransferred.graphql
@@ -6,6 +6,7 @@ query GetAssetTransferred($blockIndex: Long!) {
       limit: 1
     ) {
       id
+      timestamp
       actions {
         raw
       }

--- a/src/graphql/GetGarageUnloads.graphql
+++ b/src/graphql/GetGarageUnloads.graphql
@@ -6,6 +6,7 @@ query GetGarageUnloads($startingBlockIndex: Long!) {
       limit: 1
     ) {
       id
+      timestamp
       actions {
         raw
       }

--- a/src/graphql/GetGarageUnloads.graphql
+++ b/src/graphql/GetGarageUnloads.graphql
@@ -6,6 +6,7 @@ query GetGarageUnloads($startingBlockIndex: Long!) {
       limit: 1
     ) {
       id
+      signer
       timestamp
       actions {
         raw

--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -6,6 +6,7 @@ import { AssetTransferredObserver } from "./observers/asset-transferred-observer
 import { GarageObserver } from "./observers/garage-observer";
 import { Signer } from "./signer";
 import { Sqlite3MonitorStateStore } from "./sqlite3-monitor-state-store";
+import { JobExecutionStore } from "./job-execution-store";
 
 const odinClient = new HeadlessGraphQLClient(
     {
@@ -60,15 +61,17 @@ test("getAssetTransferredEvents()", async () => {
     );
 
     const account = RawPrivateKey.fromHex("");
+    new jobExecutionStore = new JobExecutionStore();
     const signer = new Signer(account, heimdallClient);
     const minter = new Minter(signer);
     const stateStore = await Sqlite3MonitorStateStore.open("test");
-    const observer = new AssetTransferredObserver(minter);
+    const observer = new AssetTransferredObserver(jobExecutionStore, minter);
     await observer.notify({
         blockHash: "",
         events: evs.map((ev) => {
-            return { ...ev, blockHash: "" };
-        }),
+            return {
+                ...ev, blockHash: "", planetID: "0x100000000000",
+            }),
     });
 
     return;

--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -71,8 +71,10 @@ test("getAssetTransferredEvents()", async () => {
         blockHash: "",
         events: evs.map((ev) => {
             return {
-                ...ev, blockHash: "", planetID: "0x100000000000",
-            }
+                ...ev,
+                blockHash: "",
+                planetID: "0x100000000000",
+            };
         }),
     });
 

--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -72,7 +72,8 @@ test("getAssetTransferredEvents()", async () => {
         events: evs.map((ev) => {
             return {
                 ...ev, blockHash: "", planetID: "0x100000000000",
-            }),
+            }
+        }),
     });
 
     return;

--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -1,12 +1,12 @@
 import test from "node:test";
 import { Address, RawPrivateKey } from "@planetarium/account";
 import { HeadlessGraphQLClient } from "./headless-graphql-client";
+import { JobExecutionStore } from "./job-execution-store";
 import { Minter } from "./minter";
 import { AssetTransferredObserver } from "./observers/asset-transferred-observer";
 import { GarageObserver } from "./observers/garage-observer";
 import { Signer } from "./signer";
 import { Sqlite3MonitorStateStore } from "./sqlite3-monitor-state-store";
-import { JobExecutionStore } from "./job-execution-store";
 
 const odinClient = new HeadlessGraphQLClient(
     {
@@ -33,6 +33,8 @@ const heimdallClient = new HeadlessGraphQLClient(
     1,
 );
 
+const jobExecutionStore = new JobExecutionStore();
+
 test(".getGarageUnloadEvents()", async () => {
     const x = await odinClient.getGarageUnloadEvents(
         8286963,
@@ -43,11 +45,11 @@ test(".getGarageUnloadEvents()", async () => {
     const account = RawPrivateKey.fromHex("");
     const signer = new Signer(account, heimdallClient);
     const minter = new Minter(signer);
-    const observer = new GarageObserver(minter);
+    const observer = new GarageObserver(jobExecutionStore, minter);
     await observer.notify({
         blockHash: "",
         events: x.map((ev) => {
-            return { ...ev, blockHash: "" };
+            return { ...ev, blockHash: "", planetID: "" };
         }),
     });
 
@@ -61,7 +63,6 @@ test("getAssetTransferredEvents()", async () => {
     );
 
     const account = RawPrivateKey.fromHex("");
-    new jobExecutionStore = new JobExecutionStore();
     const signer = new Signer(account, heimdallClient);
     const minter = new Minter(signer);
     const stateStore = await Sqlite3MonitorStateStore.open("test");

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -125,12 +125,12 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                     ).length === 0
                     ? null
                     : {
-                        txId: tx.id,
-                        timestamp: tx.timestamp,
-                        fungibleAssetValues,
-                        fungibleItems,
-                        memo,
-                    };
+                          txId: tx.id,
+                          timestamp: tx.timestamp,
+                          fungibleAssetValues,
+                          fungibleItems,
+                          memo,
+                      };
             })
             .filter((ev) => ev !== null);
     }

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -37,17 +37,6 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
         this._client = new Client({
             url: endpoint,
             exchanges: [
-                mapExchange({
-                    onOperation(operation) {
-                        
-                    },
-                    onResult(result) {
-                        
-                    },
-                    onError(error, operation) {
-                        
-                    },
-                })
                 retryExchange({
                     initialDelayMs: 1000,
                     maxDelayMs: 10000,
@@ -74,6 +63,10 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
         console.log(
             `GQL client initialization complete - ${this._planet.id} - ${endpoint}`,
         );
+    }
+
+    public getPlanetID(): string {
+        return this._planet.id;
     }
 
     private getEndpoint(): string {

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -126,6 +126,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                     ? null
                     : {
                           txId: tx.id,
+                          signer: tx.signer,
                           timestamp: tx.timestamp,
                           fungibleAssetValues,
                           fungibleItems,

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -1,7 +1,7 @@
 import { Address } from "@planetarium/account";
 import { BencodexDictionary, Dictionary, decode } from "@planetarium/bencodex";
 import { Currency, FungibleAssetValue } from "@planetarium/tx";
-import { Client, fetchExchange } from "@urql/core";
+import { Client, fetchExchange, mapExchange } from "@urql/core";
 import { retryExchange } from "@urql/exchange-retry";
 import {
     GetAssetTransferredDocument,
@@ -37,6 +37,17 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
         this._client = new Client({
             url: endpoint,
             exchanges: [
+                mapExchange({
+                    onOperation(operation) {
+                        
+                    },
+                    onResult(result) {
+                        
+                    },
+                    onError(error, operation) {
+                        
+                    },
+                })
                 retryExchange({
                     initialDelayMs: 1000,
                     maxDelayMs: 10000,
@@ -121,11 +132,11 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                     ).length === 0
                     ? null
                     : {
-                          txId: tx.id,
-                          fungibleAssetValues,
-                          fungibleItems,
-                          memo,
-                      };
+                        txId: tx.id,
+                        fungibleAssetValues,
+                        fungibleItems,
+                        memo,
+                    };
             })
             .filter((ev) => ev !== null);
     }

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -126,6 +126,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                     ? null
                     : {
                         txId: tx.id,
+                        timestamp: tx.timestamp,
                         fungibleAssetValues,
                         fungibleItems,
                         memo,
@@ -164,6 +165,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
         return data.data.transaction.ncTransactions
             .map((tx) => {
                 const txId = tx.id;
+                const timestamp = tx.timestamp;
                 const action = decode(
                     Buffer.from(tx.actions[0].raw, "hex"),
                 ) as Dictionary;
@@ -190,6 +192,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
 
                 return {
                     txId,
+                    timestamp,
                     sender,
                     recipient,
                     amount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ import { AssetBurner } from "./asset-burner";
 import { AssetTransfer } from "./asset-transfer";
 import { getRequiredEnv } from "./env";
 import { HeadlessGraphQLClient } from "./headless-graphql-client";
+import { IJobExecutionStore } from "./interfaces/job-execution-store";
 import { IMonitorStateStore } from "./interfaces/monitor-state-store";
+import { JobExecutionStore } from "./job-execution-store";
 import { Minter } from "./minter";
 import { getMonitorStateHandler } from "./monitor-state-handler";
 import { AssetsTransferredMonitor } from "./monitors/assets-transferred-monitor";
@@ -33,6 +35,7 @@ import { Planet } from "./types/registry";
         await Sqlite3MonitorStateStore.open(
             getRequiredEnv("MONITOR_STATE_STORE_PATH"),
         );
+    const jobExecutionStore: IJobExecutionStore = new JobExecutionStore();
 
     const upstreamAssetsTransferredMonitorMonitor =
         new AssetsTransferredMonitor(
@@ -40,6 +43,7 @@ import { Planet } from "./types/registry";
                 monitorStateStore,
                 "upstreamAssetTransferMonitor",
             ),
+            jobExecutionStore,
             upstreamGQLClient,
             Address.fromHex(getRequiredEnv("NC_VAULT_ADDRESS")),
         );
@@ -49,6 +53,7 @@ import { Planet } from "./types/registry";
                 monitorStateStore,
                 "downstreamAssetTransferMonitor",
             ),
+            jobExecutionStore,
             downstreamGQLClient,
             Address.fromHex(getRequiredEnv("NC_VAULT_ADDRESS")),
         );
@@ -57,6 +62,7 @@ import { Planet } from "./types/registry";
             monitorStateStore,
             "upstreamGarageUnloadMonitor",
         ),
+        jobExecutionStore,
         upstreamGQLClient,
         Address.fromHex(getRequiredEnv("NC_VAULT_ADDRESS")),
         Address.fromHex(getRequiredEnv("NC_VAULT_AVATAR_ADDRESS")),
@@ -74,11 +80,15 @@ import { Planet } from "./types/registry";
     const downstreamBurner = new AssetBurner(downstreamSigner);
 
     upstreamAssetsTransferredMonitorMonitor.attach(
-        new AssetTransferredObserver(minter),
+        new AssetTransferredObserver(jobExecutionStore, minter),
     );
 
     downstreamAssetsTransferredMonitorMonitor.attach(
-        new AssetDownstreamObserver(upstreamTransfer, downstreamBurner),
+        new AssetDownstreamObserver(
+            jobExecutionStore,
+            upstreamTransfer,
+            downstreamBurner,
+        ),
     );
 
     const slackBot = new SlackBot(
@@ -95,8 +105,8 @@ import { Planet } from "./types/registry";
             await downstreamAccount.getAddress(),
         ),
     );
-
-    garageMonitor.attach(new GarageObserver(minter));
+    
+    garageMonitor.attach(new GarageObserver(jobExecutionStore, minter));
 
     const handleSignal = () => {
         console.log("Handle signal.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ import { Planet } from "./types/registry";
             await downstreamAccount.getAddress(),
         ),
     );
-    
+
     garageMonitor.attach(new GarageObserver(jobExecutionStore, minter));
 
     const handleSignal = () => {

--- a/src/interfaces/asset-burner.ts
+++ b/src/interfaces/asset-burner.ts
@@ -1,5 +1,6 @@
 import { FungibleAssetValue } from "@planetarium/tx";
 
 export interface IAssetBurner {
+    getBurnerPlanet(): string;
     burn(amount: FungibleAssetValue, memo: string): Promise<string>;
 }

--- a/src/interfaces/asset-transfer.ts
+++ b/src/interfaces/asset-transfer.ts
@@ -2,6 +2,7 @@ import { Address } from "@planetarium/account";
 import { FungibleAssetValue } from "@planetarium/tx";
 
 export interface IAssetTransfer {
+    getTransferPlanet(): string;
     transfer(
         recipient: Address,
         amount: FungibleAssetValue,

--- a/src/interfaces/headless-graphql-client.ts
+++ b/src/interfaces/headless-graphql-client.ts
@@ -6,6 +6,7 @@ import { TransactionResult } from "../types/transaction-result";
 import { TxId } from "../types/txid";
 
 export interface IHeadlessGraphQLClient {
+    getPlanetID(): string;
     getBlockIndex(blockHash: BlockHash): Promise<number>;
     getTipIndex(): Promise<number>;
     getBlockHash(index: number): Promise<BlockHash>;

--- a/src/interfaces/job-execution-store.ts
+++ b/src/interfaces/job-execution-store.ts
@@ -1,15 +1,20 @@
-import { Job, PrismaClient, ActionType } from "@prisma/client";
-import { GarageUnloadEvent } from "../types/garage-unload-event";
-import { IJobExecutionStore } from "./interfaces/job-execution-store";
+import { ActionType, Job, PrismaClient } from "@prisma/client";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
+import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { TransactionLocation } from "../types/transaction-location";
+import { IJobExecutionStore } from "./interfaces/job-execution-store";
 
 export interface IJobExecutionStore {
     putAssetTransferReq(
-        event: AssetTransferredEvent & TransactionLocation
+        event: AssetTransferredEvent & TransactionLocation,
     ): Promise<void>;
     putGarageUnloadReq(
-        event: GarageUnloadEvent & TransactionLocation
+        event: GarageUnloadEvent & TransactionLocation,
     ): Promise<void>;
-    putJobExec(reqTxId: string, resTxId: string, dstPlanet: string, actionType: ActionType);
+    putJobExec(
+        reqTxId: string,
+        resTxId: string,
+        dstPlanet: string,
+        actionType: ActionType,
+    );
 }

--- a/src/interfaces/job-execution-store.ts
+++ b/src/interfaces/job-execution-store.ts
@@ -1,0 +1,15 @@
+import { Job, PrismaClient, ActionType } from "@prisma/client";
+import { GarageUnloadEvent } from "../types/garage-unload-event";
+import { IJobExecutionStore } from "./interfaces/job-execution-store";
+import { AssetTransferredEvent } from "../types/asset-transferred-event";
+import { TransactionLocation } from "../types/transaction-location";
+
+export interface IJobExecutionStore {
+    putAssetTransferReq(
+        event: AssetTransferredEvent & TransactionLocation
+    ): Promise<void>;
+    putGarageUnloadReq(
+        event: GarageUnloadEvent & TransactionLocation
+    ): Promise<void>;
+    putJobExec(reqTxId: string, resTxId: string, dstPlanet: string, actionType: ActionType);
+}

--- a/src/interfaces/job-execution-store.ts
+++ b/src/interfaces/job-execution-store.ts
@@ -2,7 +2,6 @@ import { ActionType, Job, PrismaClient } from "@prisma/client";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { TransactionLocation } from "../types/transaction-location";
-import { IJobExecutionStore } from "./interfaces/job-execution-store";
 
 export interface IJobExecutionStore {
     putAssetTransferReq(

--- a/src/interfaces/minter.ts
+++ b/src/interfaces/minter.ts
@@ -16,6 +16,7 @@ export interface IFungibleItems {
 
 export interface IMinter {
     getMinterAddress(): Promise<Address>;
+    getMinterPlanet(): string;
 
     mintAssets(
         assets: [IFungibleAssetValues | IFungibleItems],

--- a/src/job-execution-store.ts
+++ b/src/job-execution-store.ts
@@ -1,0 +1,74 @@
+import { $Enums, PrismaClient } from "@prisma/client";
+import { IJobExecutionStore } from "./interfaces/job-execution-store";
+import { AssetTransferredEvent } from "./types/asset-transferred-event";
+import { GarageUnloadEvent } from "./types/garage-unload-event";
+import { TransactionLocation } from "./types/transaction-location";
+
+export class JobExecutionStore implements IJobExecutionStore {
+    private _prisma: PrismaClient;
+
+    constructor() {
+        this._prisma = new PrismaClient();
+    }
+    async putAssetTransferReq(
+        event: AssetTransferredEvent & TransactionLocation
+    ) {
+        await this._prisma.request.create({
+            data: {
+                req_tx_id: event.txId,
+                src_planet: event.planetID,
+                req_type: "TRANSFER_ASSETS",
+                timestamp: new Date(event.timestamp),
+                transfer: {
+                    create: {
+                        sender: event.sender.toString(),
+                        recipient: event.memo,
+                        ticker: "NCG", //...need to be adjusted in case of non-NCG bridging?
+                        amount: event.amount.rawValue.toString(),
+                    },
+                },
+                job: {
+                    create: {
+                        startedAt: new Date(event.timestamp)
+                    }
+                }
+            },
+        });
+    }
+    async putGarageUnloadReq(event: GarageUnloadEvent & TransactionLocation) {
+        const parsed = JSON.parse(event.memo);
+
+        await this._prisma.request.create({
+            data: {
+                req_tx_id: event.txId,
+                src_planet: event.planetID,
+                req_type: "UNLOAD_GARAGE",
+                timestamp: new Date(event.timestamp),
+                garage: {
+                    create: {
+                        sender: event.signer,
+                        recipient: parsed[0],
+                        recipientAvatar: parsed[1],
+                        FungibleAssetValues: JSON.stringify(event.fungibleAssetValues),
+                        FungibleItems: JSON.stringify(event.fungibleItems),
+                    },
+                },
+                job: {
+                    create: {
+                        startedAt: new Date(event.timestamp),
+                    }
+                }
+            },
+        });
+    }
+    async putJobExec(reqTxId: string, resTxId: string, dstPlanet: string, actionType: $Enums.ActionType) {
+        await this._prisma.jobExecution.create({
+            data: {
+                jobId: reqTxId,
+                dstPlanetId: dstPlanet,
+                transactionId: resTxId,
+                actionType: actionType,
+            }
+        })
+    }
+}

--- a/src/job-execution-store.ts
+++ b/src/job-execution-store.ts
@@ -11,7 +11,7 @@ export class JobExecutionStore implements IJobExecutionStore {
         this._prisma = new PrismaClient();
     }
     async putAssetTransferReq(
-        event: AssetTransferredEvent & TransactionLocation
+        event: AssetTransferredEvent & TransactionLocation,
     ) {
         await this._prisma.request.create({
             data: {
@@ -29,9 +29,9 @@ export class JobExecutionStore implements IJobExecutionStore {
                 },
                 job: {
                     create: {
-                        startedAt: new Date(event.timestamp)
-                    }
-                }
+                        startedAt: new Date(event.timestamp),
+                    },
+                },
             },
         });
     }
@@ -49,26 +49,33 @@ export class JobExecutionStore implements IJobExecutionStore {
                         sender: event.signer,
                         recipient: parsed[0],
                         recipientAvatar: parsed[1],
-                        FungibleAssetValues: JSON.stringify(event.fungibleAssetValues),
+                        FungibleAssetValues: JSON.stringify(
+                            event.fungibleAssetValues,
+                        ),
                         FungibleItems: JSON.stringify(event.fungibleItems),
                     },
                 },
                 job: {
                     create: {
                         startedAt: new Date(event.timestamp),
-                    }
-                }
+                    },
+                },
             },
         });
     }
-    async putJobExec(reqTxId: string, resTxId: string, dstPlanet: string, actionType: $Enums.ActionType) {
+    async putJobExec(
+        reqTxId: string,
+        resTxId: string,
+        dstPlanet: string,
+        actionType: $Enums.ActionType,
+    ) {
         await this._prisma.jobExecution.create({
             data: {
                 jobId: reqTxId,
                 dstPlanetId: dstPlanet,
                 transactionId: resTxId,
                 actionType: actionType,
-            }
-        })
+            },
+        });
     }
 }

--- a/src/minter.ts
+++ b/src/minter.ts
@@ -33,6 +33,10 @@ export class Minter implements IMinter {
     getMinterAddress(): Promise<Address> {
         return this.signer.getAddress();
     }
+
+    getMinterPlanet(): string {
+        return this.signer.getSignPlanet();
+    }
 }
 
 function encodeMintSpec(value: IFungibleAssetValues | IFungibleItems): Value {

--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -1,6 +1,7 @@
 import { Address } from "@planetarium/account";
 import { Job } from "@prisma/client";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { TransactionLocation } from "../types/transaction-location";

--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -7,6 +7,7 @@ import { NineChroniclesMonitor } from "./ninechronicles-block-monitor";
 
 export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransferredEvent> {
     private readonly _address: Address;
+    private readonly _planetID: string;
 
     constructor(
         monitorStateHandler: IMonitorStateHandler,
@@ -15,11 +16,13 @@ export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransfe
     ) {
         super(monitorStateHandler, headlessGraphQLClient);
         this._address = address;
+        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     protected async getEvents(
         blockIndex: number,
     ): Promise<(AssetTransferredEvent & TransactionLocation)[]> {
+        const planetID = this._planetID;
         const blockHash =
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events =
@@ -40,7 +43,7 @@ export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransfe
         }
 
         return successEvents.map((ev) => {
-            return { blockHash, ...ev };
+            return { blockHash, planetID, ...ev };
         });
     }
 }

--- a/src/monitors/assets-transferred-monitor.ts
+++ b/src/monitors/assets-transferred-monitor.ts
@@ -1,4 +1,5 @@
 import { Address } from "@planetarium/account";
+import { Job } from "@prisma/client";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
 import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
@@ -7,22 +8,21 @@ import { NineChroniclesMonitor } from "./ninechronicles-block-monitor";
 
 export class AssetsTransferredMonitor extends NineChroniclesMonitor<AssetTransferredEvent> {
     private readonly _address: Address;
-    private readonly _planetID: string;
 
     constructor(
         monitorStateHandler: IMonitorStateHandler,
+        jobExecutionStore: IJobExecutionStore,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         address: Address,
     ) {
-        super(monitorStateHandler, headlessGraphQLClient);
+        super(monitorStateHandler, jobExecutionStore, headlessGraphQLClient);
         this._address = address;
-        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     protected async getEvents(
         blockIndex: number,
     ): Promise<(AssetTransferredEvent & TransactionLocation)[]> {
-        const planetID = this._planetID;
+        const planetID = this._headlessGraphQLClient.getPlanetID();
         const blockHash =
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events =

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -8,6 +8,7 @@ import { NineChroniclesMonitor } from "./ninechronicles-block-monitor";
 export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent> {
     private readonly _agentAddress: Address;
     private readonly _avatarAddress: Address;
+    private readonly _planetID: string;
 
     constructor(
         monitorStateHandler: IMonitorStateHandler,
@@ -18,11 +19,13 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
         super(monitorStateHandler, headlessGraphQLClient);
         this._agentAddress = agentAddress;
         this._avatarAddress = avatarAddress;
+        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     protected async getEvents(
         blockIndex: number,
     ): Promise<(GarageUnloadEvent & TransactionLocation)[]> {
+        const planetID = this._planetID;
         const blockHash =
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events = await this._headlessGraphQLClient.getGarageUnloadEvents(
@@ -43,7 +46,7 @@ export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent
         }
 
         return successEvents.map((ev) => {
-            return { blockHash, ...ev };
+            return { blockHash, planetID, ...ev };
         });
     }
 }

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -1,5 +1,6 @@
 import { Address } from "@planetarium/account";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { GarageUnloadEvent } from "../types/garage-unload-event";
 import { TransactionLocation } from "../types/transaction-location";

--- a/src/monitors/garage-unload-monitor.ts
+++ b/src/monitors/garage-unload-monitor.ts
@@ -8,24 +8,23 @@ import { NineChroniclesMonitor } from "./ninechronicles-block-monitor";
 export class GarageUnloadMonitor extends NineChroniclesMonitor<GarageUnloadEvent> {
     private readonly _agentAddress: Address;
     private readonly _avatarAddress: Address;
-    private readonly _planetID: string;
 
     constructor(
         monitorStateHandler: IMonitorStateHandler,
+        jobExecutionStore: IJobExecutionStore,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         agentAddress: Address,
         avatarAddress: Address,
     ) {
-        super(monitorStateHandler, headlessGraphQLClient);
+        super(monitorStateHandler, jobExecutionStore, headlessGraphQLClient);
         this._agentAddress = agentAddress;
         this._avatarAddress = avatarAddress;
-        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     protected async getEvents(
         blockIndex: number,
     ): Promise<(GarageUnloadEvent & TransactionLocation)[]> {
-        const planetID = this._planetID;
+        const planetID = this._headlessGraphQLClient.getPlanetID();
         const blockHash =
             await this._headlessGraphQLClient.getBlockHash(blockIndex);
         const events = await this._headlessGraphQLClient.getGarageUnloadEvents(

--- a/src/monitors/index.ts
+++ b/src/monitors/index.ts
@@ -3,6 +3,7 @@ import { BlockHash } from "../types/block-hash";
 
 type IMonitorObserver<TEvent> = IObserver<{
     blockHash: BlockHash;
+    planetID: string;
     events: TEvent[];
 }>;
 
@@ -31,6 +32,7 @@ export abstract class Monitor<TEvent> {
 
     abstract loop(): AsyncIterableIterator<{
         blockHash: string;
+        planetID: string;
         events: TEvent[];
     }>;
 

--- a/src/monitors/ninechronicles-block-monitor.ts
+++ b/src/monitors/ninechronicles-block-monitor.ts
@@ -18,6 +18,7 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 > {
     private readonly _monitorStateHandler: IMonitorStateHandler;
     private readonly _delayMilliseconds: number;
+    private readonly _planetID: string;
 
     protected readonly _headlessGraphQLClient: IHeadlessGraphQLClient;
 
@@ -33,13 +34,16 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
         this._monitorStateHandler = monitorStateHandler;
         this._headlessGraphQLClient = headlessGraphQLClient;
         this._delayMilliseconds = delayMilliseconds;
+        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     async *loop(): AsyncIterableIterator<{
         blockHash: BlockHash;
+        planetID: string;
         events: (TEventData & TransactionLocation)[];
     }> {
         const nullableLatestBlockHash = await this._monitorStateHandler.load();
+        const planetID = this._planetID;
         if (nullableLatestBlockHash !== null) {
             this.latestBlockNumber = await this.getBlockIndex(
                 nullableLatestBlockHash,
@@ -64,6 +68,7 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 
                     yield {
                         blockHash,
+                        planetID,
                         events: await this.getEvents(blockIndex),
                     };
 

--- a/src/monitors/ninechronicles-block-monitor.ts
+++ b/src/monitors/ninechronicles-block-monitor.ts
@@ -41,6 +41,7 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 
     async *loop(): AsyncIterableIterator<{
         blockHash: BlockHash;
+        planetID: string;
         events: (TEventData & TransactionLocation)[];
     }> {
         const nullableLatestBlockHash = await this._monitorStateHandler.load();
@@ -51,6 +52,7 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
         } else {
             this.latestBlockNumber = await this.getTipIndex();
         }
+        const planetID = this._headlessGraphQLClient.getPlanetID();
 
         while (this.isRunnning()) {
             console.log(
@@ -68,6 +70,7 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 
                     yield {
                         blockHash,
+                        planetID,
                         events: await this.getEvents(blockIndex),
                     };
 

--- a/src/monitors/ninechronicles-block-monitor.ts
+++ b/src/monitors/ninechronicles-block-monitor.ts
@@ -1,6 +1,8 @@
+import { Job } from "@prisma/client";
 import { captureException } from "@sentry/node";
 import { Monitor } from ".";
 import { IHeadlessGraphQLClient } from "../interfaces/headless-graphql-client";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import { IMonitorStateHandler } from "../interfaces/monitor-state-handler";
 import { BlockHash } from "../types/block-hash";
 import { TransactionLocation } from "../types/transaction-location";
@@ -18,14 +20,14 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 > {
     private readonly _monitorStateHandler: IMonitorStateHandler;
     private readonly _delayMilliseconds: number;
-    private readonly _planetID: string;
-
+    protected readonly _jobExecutionStore: IJobExecutionStore;
     protected readonly _headlessGraphQLClient: IHeadlessGraphQLClient;
 
     private latestBlockNumber: number | undefined;
 
     constructor(
         monitorStateHandler: IMonitorStateHandler,
+        jobExecutionStore: IJobExecutionStore,
         headlessGraphQLClient: IHeadlessGraphQLClient,
         delayMilliseconds: number = 15 * 1000,
     ) {
@@ -33,17 +35,15 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 
         this._monitorStateHandler = monitorStateHandler;
         this._headlessGraphQLClient = headlessGraphQLClient;
+        this._jobExecutionStore = jobExecutionStore;
         this._delayMilliseconds = delayMilliseconds;
-        this._planetID = this._headlessGraphQLClient.getPlanetID();
     }
 
     async *loop(): AsyncIterableIterator<{
         blockHash: BlockHash;
-        planetID: string;
         events: (TEventData & TransactionLocation)[];
     }> {
         const nullableLatestBlockHash = await this._monitorStateHandler.load();
-        const planetID = this._planetID;
         if (nullableLatestBlockHash !== null) {
             this.latestBlockNumber = await this.getBlockIndex(
                 nullableLatestBlockHash,
@@ -68,7 +68,6 @@ export abstract class NineChroniclesMonitor<TEventData> extends Monitor<
 
                     yield {
                         blockHash,
-                        planetID,
                         events: await this.getEvents(blockIndex),
                     };
 

--- a/src/observers/asset-downstream-observer.ts
+++ b/src/observers/asset-downstream-observer.ts
@@ -54,6 +54,12 @@ export class AssetDownstreamObserver
             try {
                 this.debug("Try to burn");
                 const burnTxId = await this._burner.burn(ev.amount, ev.txId);
+                this.jobExecutionStore.putJobExec(
+                    ev.txId,
+                    burnTxId,
+                    this._burner.getBurnerPlanet(),
+                    "BURN",
+                );
                 this.debug("BurnAsset TxId is", burnTxId);
 
                 const targetAddress = Address.fromHex(ev.memo);
@@ -79,6 +85,12 @@ export class AssetDownstreamObserver
                     targetAddress,
                     amount,
                     null,
+                );
+                this.jobExecutionStore.putJobExec(
+                    ev.txId,
+                    transferTxId,
+                    this._transfer.getTransferPlanet(),
+                    "TRANSFER",
                 );
                 this.debug("TransferAsset TxId is", transferTxId);
             } catch (e) {

--- a/src/observers/asset-downstream-observer.ts
+++ b/src/observers/asset-downstream-observer.ts
@@ -2,6 +2,7 @@ import { Address } from "@planetarium/account";
 import { IObserver } from ".";
 import { IAssetBurner } from "../interfaces/asset-burner";
 import { IAssetTransfer } from "../interfaces/asset-transfer";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { BlockHash } from "../types/block-hash";
 import { TransactionLocation } from "../types/transaction-location";
@@ -13,10 +14,12 @@ export class AssetDownstreamObserver
             events: (AssetTransferredEvent & TransactionLocation)[];
         }>
 {
+    private readonly jobExecutionStore: IJobExecutionStore;
     private readonly _transfer: IAssetTransfer;
     private readonly _burner: IAssetBurner;
 
     constructor(
+        jobExecutionStore: IJobExecutionStore,
         upstreamTransfer: IAssetTransfer,
         downstreamBurner: IAssetBurner,
     ) {

--- a/src/observers/asset-transferred-observer.ts
+++ b/src/observers/asset-transferred-observer.ts
@@ -40,9 +40,15 @@ export class AssetTransferredObserver
                 rawValue: amount.rawValue,
             };
 
-            await this._minter.mintAssets(
+            const resTxId = await this._minter.mintAssets(
                 [{ recipient, amount: amountToMint }],
                 null,
+            );
+            await this.jobExecutionStore.putJobExec(
+                txId,
+                resTxId,
+                this._minter.getMinterPlanet(),
+                "MINT",
             );
         }
     }

--- a/src/observers/asset-transferred-observer.ts
+++ b/src/observers/asset-transferred-observer.ts
@@ -1,5 +1,6 @@
 import { FungibleAssetValue } from "@planetarium/tx";
 import { IObserver } from ".";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import { IMinter } from "../interfaces/minter";
 import { AssetTransferredEvent } from "../types/asset-transferred-event";
 import { BlockHash } from "../types/block-hash";
@@ -9,12 +10,15 @@ export class AssetTransferredObserver
     implements
         IObserver<{
             blockHash: BlockHash;
+            planetID: string;
             events: (AssetTransferredEvent & TransactionLocation)[];
         }>
 {
     private readonly _minter: IMinter;
+    private readonly jobExecutionStore: IJobExecutionStore;
 
-    constructor(minter: IMinter) {
+    constructor(jobExecutionStore: IJobExecutionStore, minter: IMinter) {
+        this.jobExecutionStore = jobExecutionStore;
         this._minter = minter;
     }
 

--- a/src/observers/garage-observer.spec.ts
+++ b/src/observers/garage-observer.spec.ts
@@ -32,6 +32,7 @@ test("notify", async () => {
         blockHash: "xxx",
         events: [
             {
+                signer: "0xcb75c84d76a6f97a2d55882aea4436674c288673",
                 blockHash: "xxx",
                 planetID: "0x100000000000",
                 fungibleAssetValues: [

--- a/src/observers/garage-observer.spec.ts
+++ b/src/observers/garage-observer.spec.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import { RawPrivateKey } from "@planetarium/account";
 import { HeadlessGraphQLClient } from "../headless-graphql-client";
+import { JobExecutionStore } from "../job-execution-store";
 import { Minter } from "../minter";
 import { Signer } from "../signer";
 import { Sqlite3MonitorStateStore } from "../sqlite3-monitor-state-store";
@@ -8,6 +9,7 @@ import { GarageObserver } from "./garage-observer";
 
 test("notify", async () => {
     const monitorStateStore = await Sqlite3MonitorStateStore.open("test");
+    const jobExecutionStore = await new JobExecutionStore();
     const account = RawPrivateKey.fromHex("");
     const signer = new Signer(
         account,
@@ -25,12 +27,13 @@ test("notify", async () => {
         ),
     );
     const minter = new Minter(signer);
-    const observer = new GarageObserver(minter);
+    const observer = new GarageObserver(jobExecutionStore, minter);
     observer.notify({
         blockHash: "xxx",
         events: [
             {
                 blockHash: "xxx",
+                planetID: "0x100000000000",
                 fungibleAssetValues: [
                     [
                         await account.getAddress(),
@@ -53,6 +56,7 @@ test("notify", async () => {
                         100,
                     ],
                 ],
+                timestamp: "2023-11-20T13:54:42.227818+00:00",
                 txId: "",
                 memo: JSON.stringify([
                     "0x019101FEec7ed4f918D396827E1277DEda1e20D4",

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -62,7 +62,16 @@ export class GarageObserver
 
             if (requests.length !== 0) {
                 // @ts-ignore
-                await this._minter.mintAssets(requests, memoForMinter);
+                const resTxId = await this._minter.mintAssets(
+                    requests,
+                    memoForMinter,
+                );
+                this.jobExecutionStore.putJobExec(
+                    txId,
+                    resTxId,
+                    this._minter.getMinterPlanet(),
+                    "MINT",
+                );
             }
         }
     }

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -1,4 +1,5 @@
 import { IObserver } from ".";
+import { IJobExecutionStore } from "../interfaces/job-execution-store";
 import {
     IFungibleAssetValues,
     IFungibleItems,
@@ -16,9 +17,11 @@ export class GarageObserver
         }>
 {
     private readonly _minter: IMinter;
+    private readonly jobExecutionStore: IJobExecutionStore;
 
-    constructor(minter: IMinter) {
+    constructor(jobExecutionStore: IJobExecutionStore, minter: IMinter) {
         this._minter = minter;
+        this.jobExecutionStore = jobExecutionStore;
     }
 
     async notify(data: {
@@ -30,6 +33,7 @@ export class GarageObserver
         for (const {
             blockHash,
             txId,
+            planetID,
             fungibleAssetValues,
             fungibleItems,
             memo,

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -61,8 +61,8 @@ export class GarageObserver
             }
 
             if (requests.length !== 0) {
-                // @ts-ignore
                 const resTxId = await this._minter.mintAssets(
+                    // @ts-ignore
                     requests,
                     memoForMinter,
                 );

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -20,6 +20,10 @@ export class Signer {
         return this._account.getAddress();
     }
 
+    getSignPlanet(): string {
+        return this._client.getPlanetID();
+    }
+
     async sendTx(action: RecordView): Promise<string> {
         const address = await this._account.getAddress();
         return this.mutex.runExclusive(async () => {

--- a/src/types/asset-transferred-event.ts
+++ b/src/types/asset-transferred-event.ts
@@ -4,6 +4,7 @@ import { TxId } from "./txid";
 
 export interface AssetTransferredEvent {
     txId: TxId;
+    timestamp: string;
     sender: Address;
     recipient: Address;
     amount: FungibleAssetValue;

--- a/src/types/garage-unload-event.ts
+++ b/src/types/garage-unload-event.ts
@@ -5,6 +5,7 @@ import { TxId } from "./txid";
 
 export interface GarageUnloadEvent {
     txId: TxId;
+    timestamp: string;
     fungibleAssetValues: [Address, FungibleAssetValue][];
     fungibleItems: [Address, FungibleItemId, number][];
     memo: string | null;

--- a/src/types/garage-unload-event.ts
+++ b/src/types/garage-unload-event.ts
@@ -5,6 +5,7 @@ import { TxId } from "./txid";
 
 export interface GarageUnloadEvent {
     txId: TxId;
+    signer: string;
     timestamp: string;
     fungibleAssetValues: [Address, FungibleAssetValue][];
     fungibleItems: [Address, FungibleItemId, number][];

--- a/src/types/transaction-location.ts
+++ b/src/types/transaction-location.ts
@@ -2,6 +2,7 @@ import { BlockHash } from "./block-hash";
 import { TxId } from "./txid";
 
 export interface TransactionLocation {
+    planetID: string;
     blockHash: BlockHash;
     txId: TxId | null;
 }


### PR DESCRIPTION
This resolves #25.
## Features
- This uses Prisma + PostgreSQL to Record Transactions
  - Requests (Job)
  Transfer NCG / Garage Handling
  Holds source Planet ID
  
  - Responses (Job Execution)
  MINT, BURN, TRANSFER
  can be multiple per job (example, burn & mint)
  Holds target (destination) Planet ID it affects

- PlanetID Emit
  Each actors (signer, mint, burn, transferer) emits it's planetID from their HeadlessGQLClient.

- Add Timestamp
  _Time is gold, my friend!_

Comments
- I left monitor-state-store intentionally in-app, to guarantee sync with faults.
- Is just injecting logging methods directly into actors could be better? It will guarantee Staging with DB I/O in mutex, but not sure

TODO
- External Request Handling Logger which handle faulted bridge status
- And MVC interface for that.