### PR TITLE
🔨 PDX-185: Correct unload-garage event handling

### DIFF
--- a/src/headless-graphql-client.spec.ts
+++ b/src/headless-graphql-client.spec.ts
@@ -48,7 +48,14 @@ test(".getGarageUnloadEvents()", async () => {
         await heimdallClient.getGenesisHash(),
     );
     const minter = new Minter(signer);
-    const observer = new GarageObserver(FAKE_SLACK_MESSAGE_SENDER, minter);
+    const observer = new GarageObserver(FAKE_SLACK_MESSAGE_SENDER, minter, {
+        agentAddress: Address.fromHex(
+            "0x1c2ae97380CFB4F732049e454F6D9A25D4967c6f",
+        ),
+        avatarAddress: Address.fromHex(
+            "0x41aEFE4cdDFb57C9dFfd490e17e571705c593dDc",
+        ),
+    });
     await observer.notify({
         blockHash: "",
         events: x.map((ev) => {

--- a/src/headless-graphql-client.ts
+++ b/src/headless-graphql-client.ts
@@ -119,18 +119,24 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                 ]);
                 const memo = values[3];
 
-                return !recipientAvatarAddress.equals(avatarAddress) &&
-                    fungibleAssetValues.filter((fav) =>
-                        agentAddress.equals(fav[0]),
-                    ).length === 0
-                    ? null
-                    : {
-                          txId: tx.id,
-                          signer: tx.signer,
-                          fungibleAssetValues,
-                          fungibleItems,
-                          memo,
-                      };
+                const filteredFungibleAssetValues = fungibleAssetValues.filter(
+                    (fav) =>
+                        agentAddress.equals(fav[0]) ||
+                        avatarAddress.equals(fav[0]),
+                );
+                const filteredFungibleItems = recipientAvatarAddress.equals(
+                    avatarAddress,
+                )
+                    ? fungibleItems
+                    : [];
+
+                return {
+                    txId: tx.id,
+                    signer: tx.signer,
+                    fungibleAssetValues: filteredFungibleAssetValues,
+                    fungibleItems: filteredFungibleItems,
+                    memo,
+                };
             })
             .filter((ev) => ev !== null);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,12 @@ async function withMonitors(
         ),
     );
 
-    garageMonitor.attach(new GarageObserver(slackBot, minter));
+    garageMonitor.attach(
+        new GarageObserver(slackBot, minter, {
+            agentAddress,
+            avatarAddress,
+        }),
+    );
 
     const handleSignal = () => {
         console.log("Handle signal.");

--- a/src/observers/garage-observer.spec.ts
+++ b/src/observers/garage-observer.spec.ts
@@ -1,5 +1,5 @@
 import test, { mock } from "node:test";
-import { RawPrivateKey } from "@planetarium/account";
+import { Address, RawPrivateKey } from "@planetarium/account";
 import { ChatPostMessageResponse } from "@slack/web-api";
 import { HeadlessGraphQLClient } from "../headless-graphql-client";
 import { Minter } from "../minter";
@@ -32,7 +32,14 @@ test("notify", async () => {
         await headlessClient.getGenesisHash(),
     );
     const minter = new Minter(signer);
-    const observer = new GarageObserver(FAKE_SLACK_MESSAGE_SENDER, minter);
+    const observer = new GarageObserver(FAKE_SLACK_MESSAGE_SENDER, minter, {
+        agentAddress: Address.fromHex(
+            "0x1c2ae97380CFB4F732049e454F6D9A25D4967c6f",
+        ),
+        avatarAddress: Address.fromHex(
+            "0x41aEFE4cdDFb57C9dFfd490e17e571705c593dDc",
+        ),
+    });
     observer.notify({
         blockHash: "xxx",
         events: [

--- a/src/observers/garage-observer.ts
+++ b/src/observers/garage-observer.ts
@@ -1,3 +1,4 @@
+import { Address } from "@planetarium/account";
 import { IObserver } from ".";
 import {
     IFungibleAssetValues,
@@ -22,10 +23,22 @@ export class GarageObserver
 {
     private readonly _slackbot: ISlackMessageSender;
     private readonly _minter: IMinter;
+    private readonly _vaultAddresses: {
+        agentAddress: Address;
+        avatarAddress: Address;
+    };
 
-    constructor(slackbot: ISlackMessageSender, minter: IMinter) {
+    constructor(
+        slackbot: ISlackMessageSender,
+        minter: IMinter,
+        vaultAddresses: {
+            agentAddress: Address;
+            avatarAddress: Address;
+        },
+    ) {
         this._slackbot = slackbot;
         this._minter = minter;
+        this._vaultAddresses = vaultAddresses;
     }
 
     async notify(data: {
@@ -46,10 +59,19 @@ export class GarageObserver
             try {
                 const requests: (IFungibleAssetValues | IFungibleItems)[] = [];
                 for (const fa of fungibleAssetValues) {
-                    requests.push({
-                        recipient: agentAddress,
-                        amount: fa[1],
-                    });
+                    if (fa[0].equals(this._vaultAddresses.agentAddress)) {
+                        requests.push({
+                            recipient: agentAddress,
+                            amount: fa[1],
+                        });
+                    } else if (
+                        fa[0].equals(this._vaultAddresses.avatarAddress)
+                    ) {
+                        requests.push({
+                            recipient: avatarAddress,
+                            amount: fa[1],
+                        });
+                    }
                 }
 
                 for (const fi of fungibleItems) {


### PR DESCRIPTION
이 PR은:
- 이전에는 `fungibleAssetValues`를 unload하지 않으면 `fungibleItems`가 있더라도 아예 처리하지 않았습니다. 이제는 `fungibleItems`만 있더라도 처리하게 변경됩니다.
- 이전에는 `fungibleAssetValues`를 받는 `balanceAddr` 과는 무관하게 모두 memo를 통해 얻은 `agentAddress` 로 주었습니다. `fungibleAssetvalues`를 받는 `balanceAddr`에 따라서 bridge vault agentAddress로 주었다면 memo의 agentAddress로, vault avatarAddress로 주었다면 memo의 avatarAddress로 주게 변경됩니다. 그 외의 `fungibleAssetValues` 는 무시합니다.
- 이전에는 `recipientAvatarAddress`가 bridge vault avatarAddress과 다르다면 이벤트를 아예 무시했지만 `unload_from_my_garages` 액션 스펙 상 `recipientAvatarAddress` 와 `fungibleAssetValues[*].balanceAddr` 은 전혀 무관한 값으로 이해해서 이제는 `recipientAvatarAddress`와 bridge vault avatarAddress가 다르더라도 `fungibleAssetValues` 에 처리할 것이 있다면 처리합니다.