### PR TITLE
Send bridge error slack noti with JSON-string memo

### DIFF
--- a/src/sync/upstream/index.ts
+++ b/src/sync/upstream/index.ts
@@ -215,12 +215,16 @@ export async function processUpstreamEvents(
     }
 
     for (const ev of unloadGarageEventsWithInvalidMemo) {
-        await slackBot.sendMessage(
-            new BridgeErrorEvent(
-                [upstreamNetworkId, ev.txId],
-                new Error(`INVALID_MEMO: ${ev.parsedMemo}`),
-            ),
-        );
+        try {
+            await slackBot.sendMessage(
+                new BridgeErrorEvent(
+                    [upstreamNetworkId, ev.txId],
+                    new Error(`INVALID_MEMO: ${JSON.stringify(ev.parsedMemo)}`),
+                ),
+            );
+        } catch (e) {
+            console.error("[sync][upstream] Failed to send slack message", e);
+        }
     }
 }
 


### PR DESCRIPTION
Without this PR, it shows like `[object Object]`

<img width="718" alt="image" src="https://github.com/planetarium/NineChronicles.Bridge/assets/26626194/fe628f92-f2de-49c3-8b65-beeee9ccee1c">
